### PR TITLE
Added support for MongoEngine connection alias

### DIFF
--- a/web/db/me.py
+++ b/web/db/me.py
@@ -16,39 +16,48 @@ _safe_uri_replace = re.compile(r'(\w+)://(\w+):(?P<password>[^@]+)@')
 
 def MongoEngineMiddleware(application, prefix, model, session=None, **config):
     url = config.get('%s.url' % (prefix, ), 'mongo://localhost')
-    
+
     log.info("Connecting MongoEngine to '%s'.", _safe_uri_replace.sub(r'\1://\2@', url))
-    
+
     connection = dict(tz_aware=True)
-    
+
     scheme, parts = url.split('://', 1)
     parts, db = parts.split('/', 1)
     auth, host = parts.split('@', 1) if '@' in parts else (None, parts)
-    
+
     if scheme != 'mongo':
         raise Exception('The URL must begin with \'mongo://\'!')
-    
+
     connection['host'], connection['port'] = host.split(':') if ':' in host else (host, '27017')
     connection['port'] = int(connection['port'])
-    
+
+    alias = config.get('%s.alias' % (prefix, ), None)
+    if alias:
+        connection['alias'] = alias
+
     if auth: # pragma: no cover
         connection['username'], _, connection['password'] = auth.partition(':')
-    
+
     log.debug("Connecting to %s database with connection information: %r", db, connection)
     model.__dict__['connection'] = mongoengine.connect(db, **connection)
-    
+
+    if alias:
+        for model_class in [model.__dict__[class_name] for class_name in model.__all__]:
+            if 'db_alias' not in model_class.__dict__.get('meta', {}):
+                model_class._meta['db_alias'] = alias # Warning: MongoEngine private dict
+
     prepare = getattr(model, 'prepare', None)
     if hasattr(prepare, '__call__'):
         warnings.warn("Use of the hard-coded 'prepare' callback is deprecated.\n"
                 "Use the 'ready' callback instead.", DeprecationWarning)
         prepare()
-    
+
     cb = config.get(prefix + '.ready', None)
-    
+
     if cb is not None:
         cb = load_object(cb) if isinstance(cb, basestring) else cb
-        
+
         if hasattr(cb, '__call__'):
             cb()
-    
+
     return application


### PR DESCRIPTION
You need this if you want multiple simultaneous MongoEngine connections.

One issue is that the middleware goes through the model module's **all** and adds the alias to every class's _meta['db_alias'], which is a MongoEngine private. I like this for myself cause it's easy, I don't have to add a `meta = {'db_alias': alias}` to every model class, but it might not be appropriate for WebCore as a framework, because of black magic. Your call.
