### PR TITLE
Additional callback for post-response clean up.

### DIFF
--- a/example/extension.py
+++ b/example/extension.py
@@ -142,6 +142,16 @@ class Extension(object):
 		"""Transform outgoing values prior to view lookup."""
 		pass
 	
+	def done(self, context):
+		"""Executed after the entire response has completed generating.
+		
+		This might seem to duplicate the purpose of `after`; the distinction is with iterable or generator WSGI bodies
+		whose processing is deferred until after WebCore has returned. This callback will be executed once iteration
+		of the body is complete whereas `after` is executed prior to iteration of the body, but after endpoint
+		execution.
+		"""
+		pass
+	
 	def interactive(self):
 		"""Populate an interactive shell."""
 		return dict()

--- a/test/test_extensions/test_local.py
+++ b/test/test_extensions/test_local.py
@@ -20,7 +20,7 @@ def test_existing_thread_local_extension():
 	
 	assert local.context is rctx
 	
-	ext.after(rctx)
+	ext.done(rctx)
 	assert not hasattr(local, 'context')
 	
 	ext.stop(ctx)
@@ -43,7 +43,7 @@ def test_new_thread_local_extension():
 	
 	assert local.context is rctx
 	
-	ext.after(rctx)
+	ext.done(rctx)
 	assert not hasattr(local, 'context')
 	
 	ext.stop(ctx)

--- a/web/core/application.py
+++ b/web/core/application.py
@@ -312,5 +312,13 @@ class Application(object):
 		
 		for ext in signals.after: ext(context)
 		
-		return context.response.conditional_response_app(environ, start_response)
+		def capture_done(response):
+			for chunk in response:
+				yield response
+			
+			for ext in signals.done: ext(context)
+		
+		# This is really long due to the fact we don't want to capture the response too early.
+		# We need anything up to this point to be able to simply replace `context.response` if needed.
+		return capture_done(context.response.conditional_response_app(environ, start_response))
 

--- a/web/core/application.py
+++ b/web/core/application.py
@@ -314,7 +314,7 @@ class Application(object):
 		
 		def capture_done(response):
 			for chunk in response:
-				yield response
+				yield chunk
 			
 			for ext in signals.done: ext(context)
 		

--- a/web/core/extension.py
+++ b/web/core/extension.py
@@ -66,6 +66,7 @@ class WebExtensions(ExtensionManager):
 			'after',  # Executed after dispatch has returned and the response populated.
 			'mutate',  # Inspect and potentially mutate arguments to the handler prior to execution.
 			'transform',  # Transform the result returned by the handler and apply it to the response.
+			'done',  # Executed after the response has been consumed by the client.
 			'middleware',  # Executed to allow WSGI middleware wrapping.
 		)
 	
@@ -98,6 +99,7 @@ class WebExtensions(ExtensionManager):
 		# Certain operations act as a stack, i.e. "before" are executed in dependency order, but "after" are executed
 		# in reverse dependency order.  This is also the case with "mutate" (incoming) and "transform" (outgoing).
 		signals['after'].reverse()
+		signals['done'].reverse()
 		signals['transform'].reverse()
 		signals['middleware'].reverse()
 		

--- a/web/ext/local.py
+++ b/web/ext/local.py
@@ -77,12 +77,14 @@ class ThreadLocalExtension(object):
 			delattr(module, name)
 	
 	def prepare(self, context):
+		"""Executed prior to processing a request."""
 		if __debug__:
 			log.debug("Assigning thread local request context.")
 		
 		self.local.context = context
 	
-	def after(self, result):
+	def done(self, result):
+		"""Executed after the entire response has been sent to the client."""
 		if __debug__:
 			log.debug("Cleaning up thread local request context.")
 		


### PR DESCRIPTION
This should resolve #166 by wrapping the WSGI response body in our own iterator which knows to call the `done` extension callback upon completion.

Includes documentation, example, tests, and an updated `ThreadLocalExtension`.