### PR TITLE
Executor Extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 python:
   - "2.7"
   - "pypy"
-  - "pypy-5.7.1"
+  - "pypy3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ tests_require = [
 		'pytest-flakes',  # syntax validation
 		'web.dispatch.object',  # dispatch tests
 		'backlash',  # debug tests
+		'futures; python_version < "3.4"',  # deferred execution extension
 	]
 
 

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
 					'annotation = web.ext.annotation:AnnotationExtension',  # Preferred use/needs reference.
 					'cast = web.ext.annotation:AnnotationExtension',  # Legacy reference.
 					'typecast = web.ext.annotation:AnnotationExtension',  # Legacy reference.
+					'defer = web.ext.defer:DeferralExtension', # Executor interface.
 					'local = web.ext.local:ThreadLocalExtension',  # Preferred use/needs reference.
 					'threadlocal = web.ext.local:ThreadLocalExtension',  # Legacy reference.
 					'assets = web.ext.assets:WebAssetsExtension',  # WebAssets integration.
@@ -219,4 +220,3 @@ setup(
 			'bjoern': ['bjoern'],
 		},
 )
-

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -64,7 +64,7 @@ def test_deferred_executor():
 	deferred_executor.shutdown(wait=False)
 	assert future.running() is False
 	
-	deferred_executor.schedule_one(future)
+	deferred_executor._schedule_one(future)
 	assert future.running() is True
 
 

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -1,13 +1,9 @@
 # encoding: utf-8
 
-#import time
-#import pytest
-
 from concurrent.futures import ThreadPoolExecutor
 from webob import Request
 
 from web.core import Application
-#from web.core.context import Context
 from web.ext.defer import DeferralExtension, DeferredExecutor
 
 
@@ -91,14 +87,14 @@ class TestDeferralExtension(object):
 		assert results == ['called', 'returned', 8]
 		del results[:]
 	
-	def test_attributes_pre_schedule(self):
+	def test_attributes(self):
 		def attr(name, executed=True, immediate=False):
 			req = Request.blank('/prop/' + name + ("?invoke=True" if immediate else ""))
 			status, headers, body_iter = req.call_application(self.app)
 			result = b''.join(body_iter).decode('utf8').partition('\n')[::2]
 			# Body must complete iteration before we do any tests against the job...
 			
-			if executed:
+			if executed and name != 'cancel':
 				assert len(results) == 3
 				assert results == ['called', 'returned', 8]
 				del results[:]
@@ -108,6 +104,7 @@ class TestDeferralExtension(object):
 			return result
 		
 		assert attr('cancel', False)[1] == 'True'
+		assert attr('cancel', True)[1] == 'True'
 		
 		assert attr('cancelled')[1] == 'False'
 		assert attr('running')[1] == 'False'
@@ -118,8 +115,6 @@ class TestDeferralExtension(object):
 		
 		assert attr('_internal')[0] == 'None'
 		assert attr('_internal', immediate=True)[0] != 'None'
-		
-		# DeferredFuture(<function deferred at 0xYYYYYYYY>, *(2, 4), **{}, callbacks=1)
 	
 	def test_context(self):
 		req = Request.blank('/isa')

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -42,6 +42,12 @@ class Root(object):
 	def blank(self):
 		return "nope"
 	
+	def deferred_body(self):
+		def inner():
+			return "yup"
+		
+		return self.ctx.defer.submit(inner)
+	
 	def isa(self):
 		return type(self.ctx.defer).__name__ + '\n' + type(self.ctx.executor).__name__
 	
@@ -150,6 +156,14 @@ class TestDeferralExtension(object):
 		
 		assert defer == 'DeferredExecutor'
 		assert executor == 'ThreadPoolExecutor'
+	
+	def test_deferred_body(self):
+		req = Request.blank('/deferred_body')
+		status, headers, body_iter = req.call_application(self.app)
+		body = b''.join(body_iter).decode('utf8')
+		
+		assert body == 'yup'
+
 
 
 

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -1,0 +1,105 @@
+# encoding: utf-8
+
+from web.core.context import Context
+from web.core.util import lazy
+from web.ext.defer import DeferralExtension, DeferredExecutor
+
+
+sentinel = object()
+
+class MockFuture(object):
+	def __init__(self):
+		self.done_cbs = []
+	
+	def done(self):
+		return False
+	
+	def running(self):
+		return True
+	
+	def add_done_callback(self, cb):
+		self.done_cbs.append(cb)
+
+
+class MockExecutor(object):
+	def submit(self, func, *args, **kwarg):
+		return MockFuture()
+	
+	def shutdown(self, wait=True):
+		self._shutdown = True
+		return
+
+
+class MockDeferredExecutor(object):
+	def schedule_one(self, future):
+		future.schedule(MockExecutor())
+
+
+def test_deferred_future():
+	"""
+	test task.cancel()
+	test task.cancelled()
+	test task.running()
+	test task.done()
+	test task.result()
+	test task.exception()
+	test task.add_done_callback() with MockExecutor
+	test task.set_running_or_notify_cancel()
+	test task.schedule() with MockExecutor
+	"""
+	pass
+
+
+def test_deferred_executor():
+	executor = MockExecutor()
+	
+	deferred_executor = DeferredExecutor(executor)
+	
+	future = deferred_executor.submit(sentinel)
+	assert future is not None
+	deferred_executor.shutdown()
+	assert future.running() is True
+	
+	future = deferred_executor.submit(sentinel)
+	deferred_executor.shutdown(wait=False)
+	assert future.running() is False
+	
+	deferred_executor.schedule_one(future)
+	assert future.running() is True
+
+
+def test_defer_extension_executor():
+	ctx = Context()
+	ext = DeferralExtension(Executor=MockExecutor)
+	
+	ext.start(ctx)
+	assert hasattr(ctx, 'executor')
+	assert isinstance(ctx.executor, MockExecutor)
+	ext.stop(ctx)
+
+
+def test_defer_extension_deferred_executor():
+	ctx = Context()
+	ext = DeferralExtension(Executor=MockExecutor)
+	ext.start(ctx)
+	
+	assert hasattr(ctx, 'deferred_executor')
+	assert isinstance(ctx.deferred_executor, lazy)
+	
+	rctx = ctx._promote('RequestContext')
+	assert 'deferred_executor' not in rctx.__dict__
+	assert hasattr(rctx, 'executor')
+	
+	# done correctly executes deferred futures
+	future = rctx.deferred_executor.submit(sentinel)
+	assert 'deferred_executor' in rctx.__dict__ and isinstance(rctx.deferred_executor, DeferredExecutor)
+	ext.done(rctx)
+	assert future.running() is True
+	
+	# Test that deferred_executor is never lazy loaded if not ccessed
+	rctx = ctx._promote('RequestContext')
+	ext.done(rctx)
+	assert 'deferred_executor' not in rctx.__dict__
+	
+	ext.stop(ctx)
+	assert ctx.executor._shutdown is True

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -1,10 +1,96 @@
 # encoding: utf-8
 
-from concurrent.futures import ThreadPoolExecutor
+#import time
+#import pytest
 
-from web.core.context import Context
-from web.core.util import lazy
+from concurrent.futures import ThreadPoolExecutor
+from webob import Request
+
+from web.core import Application
+#from web.core.context import Context
 from web.ext.defer import DeferralExtension, DeferredExecutor
+
+
+sentinel = object()
+
+
+results = []
+
+
+def deferred(a, b):
+	global results
+	results.append("called")
+	return a * b
+
+
+def resulting(receipt):
+	global results
+	results.append("returned")
+	results.append(receipt.result())
+
+
+class Root(object):
+	def __init__(self, ctx):
+		self.ctx = ctx
+	
+	def __call__(self):
+		print("Submitting.")
+		receipt = self.ctx.defer.submit(deferred, 2, 4)
+		receipt.add_done_callback(resulting)
+		return repr(receipt)
+
+	def isa(self):
+		return type(self.ctx.defer).__name__ + '\n' + type(self.ctx.executor).__name__
+
+
+
+
+class TestDeferralExtension(object):
+	app = Application(Root, extensions=[DeferralExtension()])
+	
+	def dtest_use(self):
+		req = Request.blank('/')
+		status, headers, body_iter = req.call_application(self.app)
+	
+	def test_preparation(self):
+		app = Application(Root, extensions=[DeferralExtension()])
+		ctx = app._Application__context  # "private" attribute
+		
+		assert 'executor' in ctx
+		assert isinstance(ctx.executor, ThreadPoolExecutor)
+		
+		ctx = ctx._promote('RequestContext')
+		
+		assert 'defer' in ctx
+		assert isinstance(ctx.defer, DeferredExecutor)
+	
+	def test_submission(self):
+		req = Request.blank('/')
+		status, headers, body_iter = req.call_application(self.app)
+		body = b''.join(body_iter).decode('utf8')
+		# DeferredFuture(<function deferred at 0x10aed5488>, *(2, 4), **{}, callbacks=1)
+		assert body.startswith('DeferredFuture(')
+		assert 'function deferred' in body
+		assert '*(2, 4)' in body
+		assert '**{}' in body
+		assert body.endswith(', callbacks=1)')
+		
+		assert len(results) == 3
+		assert results == ['called', 'returned', 8]
+	
+	def test_context(self):
+		req = Request.blank('/isa')
+		status, headers, body_iter = req.call_application(self.app)
+		body = b''.join(body_iter).decode('utf8')
+		defer, _, executor = body.partition('\n')
+		
+		assert defer == 'DeferredExecutor'
+		assert executor == 'ThreadPoolExecutor'
+
+
+
+
+'''
 
 
 def test_deferred_future():
@@ -15,15 +101,15 @@ def test_deferred_future():
 	test task.done()
 	test task.result()
 	test task.exception()
-	test task.add_done_callback() with MockExecutor
+	test task.add_done_callback() with Executor
 	test task.set_running_or_notify_cancel()
-	test task.schedule() with MockExecutor
+	test task.schedule() with Executor
 	"""
 	pass
 
 
 def test_deferred_executor():
-	executor = MockExecutor()
+	executor = ThreadPoolExecutor()
 	
 	deferred_executor = DeferredExecutor(executor)
 	
@@ -42,36 +128,41 @@ def test_deferred_executor():
 
 def test_defer_extension_executor():
 	ctx = Context()
-	ext = DeferralExtension(Executor=MockExecutor)
+	ext = DeferralExtension(Executor=ThreadPoolExecutor)
 	
 	ext.start(ctx)
 	assert hasattr(ctx, 'executor')
-	assert isinstance(ctx.executor, MockExecutor)
+	assert isinstance(ctx.executor, ThreadPoolExecutor)
 	ext.stop(ctx)
 
 
 def test_defer_extension_deferred_executor():
 	ctx = Context()
-	ext = DeferralExtension(Executor=MockExecutor)
+	ext = DeferralExtension(Executor=ThreadPoolExecutor)
 	ext.start(ctx)
 	
-	assert hasattr(ctx, 'deferred_executor')
-	assert isinstance(ctx.deferred_executor, lazy)
+	assert hasattr(ctx, 'defer')
+	#assert isinstance(ctx.deferred_executor, lazy)
 	
 	rctx = ctx._promote('RequestContext')
-	assert 'deferred_executor' not in rctx.__dict__
+	assert 'defer' not in rctx.__dict__
 	assert hasattr(rctx, 'executor')
 	
 	# done correctly executes deferred futures
-	future = rctx.deferred_executor.submit(sentinel)
-	assert 'deferred_executor' in rctx.__dict__ and isinstance(rctx.deferred_executor, DeferredExecutor)
+	future = rctx.defer.submit(sentinel)
+	assert 'defer' in rctx.__dict__ and isinstance(rctx.defer, DeferredExecutor)
 	ext.done(rctx)
 	assert future.running() is True
 	
-	# Test that deferred_executor is never lazy loaded if not ccessed
+	# Test that deferred executor is never lazy loaded if not ccessed
 	rctx = ctx._promote('RequestContext')
 	ext.done(rctx)
-	assert 'deferred_executor' not in rctx.__dict__
+	assert 'defer' not in rctx.__dict__
 	
 	ext.stop(ctx)
 	assert ctx.executor._shutdown is True
+
+'''
+
+if __name__ == '__main__':
+	TestDeferralExtension.app.serve('wsgiref')

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -1,38 +1,10 @@
 # encoding: utf-8
 
+from concurrent.futures import ThreadPoolExecutor
+
 from web.core.context import Context
 from web.core.util import lazy
 from web.ext.defer import DeferralExtension, DeferredExecutor
-
-
-sentinel = object()
-
-class MockFuture(object):
-	def __init__(self):
-		self.done_cbs = []
-	
-	def done(self):
-		return False
-	
-	def running(self):
-		return True
-	
-	def add_done_callback(self, cb):
-		self.done_cbs.append(cb)
-
-
-class MockExecutor(object):
-	def submit(self, func, *args, **kwarg):
-		return MockFuture()
-	
-	def shutdown(self, wait=True):
-		self._shutdown = True
-		return
-
-
-class MockDeferredExecutor(object):
-	def schedule_one(self, future):
-		future.schedule(MockExecutor())
 
 
 def test_deferred_future():

--- a/test/test_extension/test_defer.py
+++ b/test/test_extension/test_defer.py
@@ -39,6 +39,9 @@ class Root(object):
 		receipt.add_done_callback(resulting)
 		return repr(receipt)
 	
+	def blank(self):
+		return "nope"
+	
 	def isa(self):
 		return type(self.ctx.defer).__name__ + '\n' + type(self.ctx.executor).__name__
 	
@@ -67,6 +70,10 @@ class TestDeferralExtension(object):
 	
 	def dtest_use(self):
 		req = Request.blank('/')
+		status, headers, body_iter = req.call_application(self.app)
+	
+	def test_non_use(self):
+		req = Request.blank('/blank')
 		status, headers, body_iter = req.call_application(self.app)
 	
 	def test_preparation(self):

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -36,7 +36,7 @@ class DeferredFuture(object):
 	
 	def cancel(self):
 		if self._internal:
-			return self._internal.cancel()
+			return self._internal.cancel()  # TODO: Test this.
 		
 		self._cancelled = True
 		return True
@@ -52,13 +52,13 @@ class DeferredFuture(object):
 	
 	def result(self, timeout=None):
 		if not self._internal and not self._schedule():
-			raise futures.CancelledError
+			raise futures.CancelledError()  # TODO: Test this.
 		
 		return self._internal.result(timeout)
 	
 	def exception(self, timeout=None):
-		if self._internal is None and self._schedule() is None:
-			raise futures.CancelledError
+		if not self._internal and not self._schedule():
+			raise futures.CancelledError()  # TODO: Test this.  I'm sensing a pattern, here.
 		
 		return self._internal.exception(timeout)
 	
@@ -111,11 +111,15 @@ class DeferredExecutor(object):
 		return future
 	
 	def map(self, func, *iterables, **kw):
-		timeout = kw.pop('timeout', None)
-		chunksize = kw.pop('chunksize', 1)
+		kwargs = {
+				'timeout': kw.pop('timeout', None),
+				'chunksize': kw.pop('chunksize', 1)
+			}
 		
 		if kw:
 			raise TypeError("map() got an unexpected keyword argument(s) '{}'".format("', '".join(kw)))
+		
+		return self._ctx.executor.map(func, *iterables, **kwargs)
 	
 	def shutdown(self, wait=True):
 		for future in self._futures:

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
-# Imports
-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import weakref
 
@@ -14,11 +12,8 @@ except ImportError:
 
 from web.core.util import lazy
 
-# Module Globals
 
 log = __import__('logging').getLogger(__name__)
-
-# Extension
 
 
 class DeferredFuture(object):
@@ -129,7 +124,7 @@ class DeferralExtension(object):
 		if Executor is None:
 			if 'max_workers' not in config:
 				config['max_workers'] = 5
-
+			
 			Executor = futures.ThreadPoolExecutor
 		
 		self._config = config

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -111,15 +111,7 @@ class DeferredExecutor(object):
 		return future
 	
 	def map(self, func, *iterables, **kw):
-		kwargs = {
-				'timeout': kw.pop('timeout', None),
-				'chunksize': kw.pop('chunksize', 1)
-			}
-		
-		if kw:
-			raise TypeError("map() got an unexpected keyword argument(s) '{}'".format("', '".join(kw)))
-		
-		return self._ctx.executor.map(func, *iterables, **kwargs)
+		return self._ctx.executor.map(func, *iterables, **kw)
 	
 	def shutdown(self, wait=True):
 		for future in self._futures:

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -82,7 +82,7 @@ class DeferredFuture(object):
 		if not executor:
 			executor = self._ctx.executor
 		
-		if not self.set_running_or_notify_cancel():
+		if self._cancelled:
 			return None
 		
 		if self._internal:  # TODO: Test this.

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -1,0 +1,154 @@
+# encoding: utf-8
+
+# Imports
+
+from __future__ import unicode_literals
+
+import weakref
+
+try:
+	from concurrent import futures
+except ImportError:
+	print("You must install the 'futures' package.")
+	raise
+
+from web.core.util import lazy
+
+# Module Globals
+
+log = __import__('logging').getLogger(__name__)
+
+# Extension
+
+
+class DeferredFuture(object):
+	__slots__ = ['_deferred', '_func', '_cancelled', '_internal', '_done_callbacks']
+	
+	def __init__(self, deferred, func, *args, **kwargs):
+		self._deferred = deferred
+		self._func = (func, args, kwargs)
+		self._cancelled = False
+		self._internal = None
+		self._done_callbacks = []
+	
+	def cancel(self):
+		if self._internal is not None:
+			return False
+		
+		self._cancelled = True
+		return True
+	
+	def cancelled(self):
+		return self._cancelled or (self._internal and self._internal.cancelled())
+	
+	def running(self):
+		return self._internal is not None and self._internal.running()
+	
+	def done(self):
+		return self._internal and self._internal.done()
+	
+	def result(self, timeout=None):
+		if self._internal is None and self.schedule() is None:
+			raise futures.CancelledError
+		
+		return self._internal.result(timeout)
+	
+	def exception(self, timeout=None):
+		if self._internal is None and self.schedule() is None:
+			raise futures.CancelledError
+		
+		return self._internal.exception(timeout)
+	
+	def add_done_callback(self, func):
+		self.done_callbacks.append(func)
+	
+	def set_running_or_notify_cancel(self):
+		if self._cancelled or self._internal:
+			return False
+		
+		return True
+	
+	def schedule(self, executor=None):
+		if executor is None:
+			if self._deferred:
+				return self._deferred.schedule_one(self)
+			raise Exception # Shouldn't be accessible this early in the process lifecycle...
+		
+		if self.set_running_or_notify_cancel() is False:
+			return None
+		
+		self._internal = executor.submit(self._func[0], *self._func[1], **self._func[2])
+		assert self._internal is not None
+		
+		for cb in self._done_callbacks:
+			self._internal.add_done_callback(cb)
+		return self._internal
+
+
+class DeferredExecutor(object):
+	__slots__ = ['_futures', '_executor', '__weakref__']
+	
+	def __init__(self, executor):
+		self._futures = []
+		self._executor = executor
+	
+	def submit(self, func, *args, **kwargs):
+		future = DeferredFuture(weakref.proxy(self), func, *args, **kwargs)
+		self._futures.append(future)
+		return future
+	
+	def map(self, func, *iterables, timeout=None, chunksize=1):
+		pass
+	
+	def schedule_one(self, future):
+		return future.schedule(self._executor)
+	
+	def shutdown(self, wait=True):
+		if wait is False:
+			self._futures = []
+			return
+		
+		while len(self._futures) > 0:
+			self._futures.pop(0).schedule(self._executor)
+
+
+class DeferralExtension(object):
+	"""Provide an interface on RequestContext to defer a background function call until after the response has finished
+	streaming to the browser.
+	
+	A mock executor interface will be added at `context.deferred_executor` that will preserve calls until the
+	extension's 'done' callback at which point the extension will flush commands to a configurable internal executor.
+	"""
+	
+	provides = ['executor', 'deferral']
+	
+	def __init__(self, Executor=None, **config):
+		"""Configure the deferral extension.
+		"""
+		
+		if Executor is None:
+			if 'max_workers' not in config:
+				config['max_workers'] = 5
+
+			Executor = futures.ThreadPoolExecutor
+		
+		self._config = config
+		self._Executor = Executor
+	
+	def _get_deferred_executor(self, context):
+		return DeferredExecutor(weakref.proxy(context.executor))
+	
+	def start(self, context):
+		context.executor = self._Executor(**self._config)
+		context.deferred_executor = lazy(self._get_deferred_executor, 'deferred_executor')
+	
+	def stop(self, context):
+		context.executor.shutdown(wait=True)
+	
+	def done(self, context):
+		if 'deferred_executor' not in context.__dict__: # Check if there's even any work to be done
+			log.debug("Deferred executor not accessed during request")
+			return
+		
+		context.deferred_executor.shutdown(wait=True)
+		log.debug("Deferred executor accessed")

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -114,10 +114,11 @@ class DeferredExecutor(object):
 		return self._ctx.executor.map(func, *iterables, **kw)
 	
 	def shutdown(self, wait=True):
-		for future in self._futures:
-			future._schedule()
-		
+		futures = [future._schedule() for future in self._futures]
 		self._futures = []
+		
+		if wait:
+			list(as_completed(futures, timeout=None if wait is True else wait))
 
 
 class DeferralExtension(object):

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -166,6 +166,14 @@ class DeferralExtension(object):
 		
 		pass
 	
+	def transform(self, context, handler, result):
+		"""Allow endpoints to return a Future (deferred or otherwise) to block on the result before continuing."""
+		
+		if isinstance(result, (futures.Future, DeferredFuture)):  # TODO: DeferredFuture should probably subclass...
+			result = result.result()
+		
+		return result
+	
 	def done(self, context):
 		"""After request processing has completed, submit any deferred tasks to the real executor."""
 		

--- a/web/ext/defer.py
+++ b/web/ext/defer.py
@@ -69,7 +69,6 @@ class DeferredFuture(object):
 		if self._cancelled or self._internal:
 			return False
 		
-		# self._internal.set_running_or_notify_cancel()
 		return True  # dubious about this...
 	
 	def _schedule(self, executor=None):


### PR DESCRIPTION
The primary purpose of this branch is to provide #181 as specified.

The current implementation does the following:

- Provide an instance of the configured concurrent.Executor on the web RequestContext
- Provide an instance of a "Deferred" executor, which proxies the configured executor but defers scheduling of the futures until after the HTTP Request life cycle. 
- Provide an interface-compliant Future proxy object for use within the request handler to schedule the deferred futures early if a result is needed during request handling.